### PR TITLE
Separate out RSpec rubocop config.

### DIFF
--- a/.rubocop-rspec.yml
+++ b/.rubocop-rspec.yml
@@ -1,0 +1,27 @@
+require:
+  - rubocop-rspec
+
+# These rules just don't align with how we write specs
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/BeforeAfterAll:
+  Enabled: false
+
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
+  Enabled: false
+
+# Maybe we're doing some unnecessary nesting, but it doesn't seem out of the ordinary for us to
+# need a little more nesting. The default is 3. If we start wanting to bump it up higher than
+# this, though, we may want to revisit what we're nesting for.
+RSpec/NestedGroups:
+  Max: 4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 require:
-  - rubocop-rspec
   - rubocop-rails
   - rubocop-capybara
   - rubocop-factory_bot
@@ -171,32 +170,3 @@ Rails/BulkChangeTable:
 # Rails logger. Don't auto-correct, leave it up to the developer.
 Rails/Output:
   AutoCorrect: false
-
-##############
-### RSpec Cops
-##############
-
-# These rules just don't align with how we write specs
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/InstanceVariable:
-  Enabled: false
-
-RSpec/BeforeAfterAll:
-  Enabled: false
-
-RSpec/SpecFilePathFormat:
-  Enabled: false
-
-RSpec/SpecFilePathSuffix:
-  Enabled: false
-
-# Maybe we're doing some unnecessary nesting, but it doesn't seem out of the ordinary for us to
-# need a little more nesting. The default is 3. If we start wanting to bump it up higher than
-# this, though, we may want to revisit what we're nesting for.
-RSpec/NestedGroups:
-  Max: 4


### PR DESCRIPTION
Separates out the RSpec Rubocop config from the main Rails config.